### PR TITLE
已弃用的参数声明

### DIFF
--- a/src/Support.php
+++ b/src/Support.php
@@ -129,7 +129,7 @@ abstract class Support
      * @param ?callable $callabel
      * @return string
      */
-    public static function exec(string $command, callable $callabel = null): string
+    public static function exec(string $command, ?callable $callabel = null): string
     {
         if (method_exists(Process::class, 'fromShellCommandline')) {
             $process = Process::fromShellCommandline($command);


### PR DESCRIPTION
Deprecation Notice: think\admin\install\Support::exec(): Implicitly marking parameter $callabel as nullable is deprecated, the explicit nullable type must be used instead in think-install/src/Support.php:132